### PR TITLE
Fixed a bug of `params` being overriden

### DIFF
--- a/api.js
+++ b/api.js
@@ -23,6 +23,9 @@ var getVideoDetails = function (credentials) {
 exports["custom"] = { 
   videosWithKeywords: function(params, credentials, cb) { 
     'use strict';
+    /* Clone the params to avoid messing with the API data */
+    params = JSON.parse(JSON.stringify(params || {}));
+    
     params.url = "http://gdata.youtube.com/feeds/api/videos?v=2";
     // Ensure we have a number to perform calculation.
     var maxResults = parseInt(params['max-results']) || 50;

--- a/api.js
+++ b/api.js
@@ -23,9 +23,6 @@ var getVideoDetails = function (credentials) {
 exports["custom"] = { 
   videosWithKeywords: function(params, credentials, cb) { 
     'use strict';
-    /* Clone the params to avoid messing with the API data */
-    params = JSON.parse(JSON.stringify(params || {}));
-    
     params.url = "http://gdata.youtube.com/feeds/api/videos?v=2";
     // Ensure we have a number to perform calculation.
     var maxResults = parseInt(params['max-results']) || 50;
@@ -94,6 +91,8 @@ exports["custom"] = {
  */
 function uploadedVideo(params, credentials, cb) {
   'use strict';
+  /* Clone the params to avoid messing with the API data */
+  params = _.clone(params);
   var BASE_API = "https://www.googleapis.com/youtube/v3",
       limit = params.maxResults || 0;
   


### PR DESCRIPTION
Previously, the `params.maxResults` was updated in every recursion to get all the videos. At the end, it had the last number of videos in the `params`. Due to Javascript's object is not referenced by value, this `maxResults` was kept in the API data.

Once the bundle was expired, SPAS went and made request again, but then `maxResults` was not the same as specified in bundle definition any more, thus providing wrong number of results.

This fix clones the `params` object in every recursion to keep the original value.