### PR TITLE
Various updates

### DIFF
--- a/api.js
+++ b/api.js
@@ -104,9 +104,9 @@ function uploadedVideo(params, credentials, cb) {
   params.part || (params.part = "snippet");
 
   spashttp.request(params, credentials, function (err, playlistResult) {
-		if (err || !playlistResult.items) {
-			return cb(err, playlistResult);
-		}
+    if (err || !playlistResult.items) {
+      return cb(err, playlistResult);
+    }
 
     var items = playlistResult.items;
 
@@ -115,7 +115,7 @@ function uploadedVideo(params, credentials, cb) {
       var videoParams = {
         url: BASE_API + "/videos",
         id: item.snippet.resourceId.videoId,
-				part: params.part
+        part: params.part
       };
       credentials.access_token && (videoParams.access_token = credentials.access_token);
 

--- a/api.js
+++ b/api.js
@@ -95,6 +95,31 @@ function playlistItems(params, credentials, cb) {
   'use strict';
   /* Clone the params to avoid messing with the API data */
   params = _.clone(params);
+  
+  if (!params.playlistId) {
+    // Retrived from channels.list for uploads playlist.
+    var channelsParams = {
+      url: BASE_V3_API + "/channels",
+      mine: true,
+      part: "contentDetails"
+    };
+
+    if (credentials.access_token) {
+      channelsParams.access_token = credentials.access_token;
+    }
+
+    return spashttp.request(channelsParams, credentials, function (err, channelsResult) {
+      if (err) {
+        return cb(err, channelsResult);
+      }
+      if (channelsResult.error && channelsResult.code !== 200) {
+        return cb(new Error(channelsResult.message), null);
+      }
+      params.playlistId = channelsResult.items[0].contentDetails.relatedPlaylists.uploads;
+      return playlistItems(params, credentials, cb);
+    });
+  }
+  
   var limit = params.maxResults || 0;
 
   if (!limit) {

--- a/api.js
+++ b/api.js
@@ -231,6 +231,7 @@ function playlistItems(params, credentials, cb) {
     // Retrived from playlist.list for uploads playlist.
     params.part = "snippet";
   }
+  params.part = params.part.replace(/,statistics/, '');
   
   if (credentials && credentials.access_token) {
     params.access_token = credentials.access_token;

--- a/api.js
+++ b/api.js
@@ -89,7 +89,7 @@ function channels(params, credentials, cb) {
     }
 
     if (channelsResult.error) {
-      return cb(channelsResult.error), null);
+      return cb(channelsResult.error, null);
     }
 
     cb(null, channelsResult.items[0][params.part]);
@@ -130,8 +130,9 @@ function playlistItems(params, credentials, cb) {
   if (!params.playlistId) {
     // Retrived from channels.list for uploads playlist.
     var channelsParams = {
-      part: "contentDetails", 
-      forUsername: params.author
+      part: "contentDetails",
+      forUsername: params.author,
+      key: params.key
     }
     return channels(channelsParams, credentials, function (err, contentDetails) {
       if (err) {
@@ -211,7 +212,8 @@ function playlistItemsWithTags(params, credentials, cb) {
     var videoParams = {
       url: BASE_V3_API + "/videos",
       id: item.snippet.id,
-      part: params.part || "snippet"
+      part: params.part || "snippet",
+      key: params.key
     };
 
     if (credentials && credentials.access_token) {

--- a/api.js
+++ b/api.js
@@ -77,7 +77,7 @@ function channels(params, credentials, cb) {
     params.part = "contentDetails";
   }
 
-  if (credentials.access_token) {
+  if (credentials && credentials.access_token) {
     params.access_token = credentials.access_token;
   }
 
@@ -154,7 +154,7 @@ function playlistItems(params, credentials, cb) {
     params.part = "snippet";
   }
   
-  if (credentials.access_token) {
+  if (credentials && credentials.access_token) {
     params.access_token = credentials.access_token;
   }
 
@@ -208,7 +208,7 @@ function playlistItemsWithTags(params, credentials, cb) {
       part: params.part || "snippet"
     };
 
-    if (credentials.access_token) {
+    if (credentials && credentials.access_token) {
       videoParams.access_token = credentials.access_token;
     }
 

--- a/api.js
+++ b/api.js
@@ -88,8 +88,8 @@ function channels(params, credentials, cb) {
       return cb(err, channelsResult);
     }
 
-    if (channelsResult.error && channelsResult.code !== 200) {
-      return cb(new Error(channelsResult.message), null);
+    if (channelsResult.error) {
+      return cb(channelsResult.error), null);
     }
 
     cb(null, channelsResult.items[0][params.part]);
@@ -169,8 +169,8 @@ function playlistItems(params, credentials, cb) {
       return cb(err, playlistResult);
     }
     
-    if (playlistResult.error && playlistResult.code !== 200) {
-      return cb(new Error(playlistResult.message), null);
+    if (playlistResult.error) {
+      return cb(playlistResult.error, null);
     }
     
     var items = playlistResult.items.map(function (item) {

--- a/api.js
+++ b/api.js
@@ -71,7 +71,9 @@ function channels(params, credentials, cb) {
   params = _.clone(params);
 
   params.url = BASE_V3_API + "/channels";
-  params.mine = true;
+  if (!params.forUsername) {
+    params.mine = true;
+  }
 
   if (!params.part) {
     params.part = "contentDetails";
@@ -127,7 +129,11 @@ function playlistItems(params, credentials, cb) {
   
   if (!params.playlistId) {
     // Retrived from channels.list for uploads playlist.
-    return channels({part: "contentDetails"}, credentials, function (err, contentDetails) {
+    var channelsParams = {
+      part: "contentDetails", 
+      forUsername: params.author
+    }
+    return channels(channelsParams, credentials, function (err, contentDetails) {
       if (err) {
         return cb(err);
       }

--- a/api.js
+++ b/api.js
@@ -94,6 +94,40 @@ function channels(params, credentials, cb) {
 }
 
 /**
+ * Retrieves a list of playlists in a channel
+ *
+ * @param {string} channelId - ID of the user's channel
+ * @param {string} [part=snippet] - comma-separated list of data to retrieve
+ * @param {Number} [maxResults] - how many to pull if set.
+ *
+ * For now, `channelId` is required. By using `v3.channels`, this ID can be
+ * acquired in the `id` property.
+ */
+function playlists(params, credentials, cb) {
+  'use strict';
+  /* Clone the params to avoid messing with the API data */
+  params = _.clone(params);
+
+  params.url = BASE_V3_API + "/playlists";
+  if (!params.part) {
+    params.part = "snippet";
+  }
+
+  if (credentials && credentials.access_token) {
+    params.access_token = credentials.access_token;
+  }
+
+  spashttp.request(params, credentials, function (err, playlistsResult) {
+    // YouTube API returns the error in the response.
+    if (err || playlistsResult.error) {
+      return cb(err || playlistsResult.error);
+    }
+
+    cb(null, playlistsResult.items);
+  });
+}
+
+/**
  * Recursively retrieves videos from a playlist
  *
  * @param {string} playlistId - The ID of the playlist (default to uploads).
@@ -293,6 +327,7 @@ function playlistItemsWithTags(params, credentials, cb) {
 exports.v3 = {
   videos: videos,
   channels: channels,
+  playlists: playlists,
   playlistItems: playlistItems,
   playlistItemsWithTags: playlistItemsWithTags
 };

--- a/api.js
+++ b/api.js
@@ -229,6 +229,9 @@ function playlistItemsWithTags(params, credentials, cb) {
   }
 
   playlistItems(params, credentials, function(err, items) {
+    if (err) {
+      return cb(err);
+    }
     async.map(items, getVideoDetails, cb);
   });
 }

--- a/api.js
+++ b/api.js
@@ -190,13 +190,12 @@ function playlists(params, credentials, cb) {
     params.access_token = credentials.access_token;
   }
 
-  spashttp.request(params, credentials, function (err, playlistsResult) {
-    // YouTube API returns the error in the response.
-    if (err || playlistsResult.error) {
-      return cb(err || playlistsResult.error);
+  requestUntil(params, credentials, function (err, items) {
+    if (err) {
+      return cb(err);
     }
 
-    cb(null, playlistsResult.items);
+    cb(null, items);
   });
 }
 

--- a/api.js
+++ b/api.js
@@ -131,7 +131,7 @@ function playlistItems(params, credentials, cb) {
       if (err) {
         return cb(err);
       }
-      
+
       params.playlistId = contentDetails.relatedPlaylists.uploads;
       return playlistItems(params, credentials, cb);
     });
@@ -168,9 +168,9 @@ function playlistItems(params, credentials, cb) {
     }
     
     var items = playlistResult.items.map(function (item) {
-      // We only need the snippet and the video's ID, which is nested inside.
+      // We need the video's ID, which is nested inside.
       item.snippet.id = item.snippet.resourceId.videoId;
-      return item.snippet;
+      return item;
     });
 
     if (limit !== items.length && playlistResult.nextPageToken) {
@@ -204,7 +204,7 @@ function playlistItemsWithTags(params, credentials, cb) {
     // Extra request per item to get the tags
     var videoParams = {
       url: BASE_V3_API + "/videos",
-      id: item.id,
+      id: item.snippet.id,
       part: params.part || "snippet"
     };
 
@@ -219,9 +219,9 @@ function playlistItemsWithTags(params, credentials, cb) {
       
       var data = result && result.items && result.items[0] && result.items[0].snippet;
       if (data) {
-        item.tags = data.snippet.tags;
+        item.snippet.tags = data.tags;
       } else {
-        item.tags = [];
+        item.snippet.tags = [];
       }
       
       callback(err, item);

--- a/api.js
+++ b/api.js
@@ -104,9 +104,9 @@ function uploadedVideo(params, credentials, cb) {
   params.part || (params.part = "snippet");
 
   spashttp.request(params, credentials, function (err, playlistResult) {
-    if (err) {
-      return cb(err, playlistResult);
-    }
+		if (err || !playlistResult.items) {
+			return cb(err, playlistResult);
+		}
 
     var items = playlistResult.items;
 
@@ -115,7 +115,7 @@ function uploadedVideo(params, credentials, cb) {
       var videoParams = {
         url: BASE_API + "/videos",
         id: item.snippet.resourceId.videoId,
-        part: "snippet"
+				part: params.part
       };
       credentials.access_token && (videoParams.access_token = credentials.access_token);
 

--- a/api.js
+++ b/api.js
@@ -121,6 +121,10 @@ function playlistItems(params, credentials, cb) {
       return cb(err, playlistResult);
     }
     
+    if (playlistResult.error && playlistResult.code !== 200) {
+      return cb(new Error(playlistResult.message), null);
+    }
+    
     var items = playlistResult.items.map(function (item) {
       // We only need the snippet and the video's ID, which is nested inside.
       item.snippet.id = item.snippet.resourceId.videoId;
@@ -138,6 +142,10 @@ function playlistItems(params, credentials, cb) {
       params.maxResults = remainings > 0? remainings : 0;
       // Recursively call the next results page, appending to the items.
       playlistItems(params, credentials, function (err, nextPageItems) {
+        if (err) {
+          return cb(err);
+        }
+        
         Array.prototype.push.apply(items, nextPageItems);
         cb(err, items);
       });

--- a/api.js
+++ b/api.js
@@ -111,6 +111,10 @@ function playlistItems(params, credentials, cb) {
     // Retrived from playlist.list for uploads playlist.
     params.part = "snippet";
   }
+  
+  if (credentials.access_token) {
+    params.access_token = credentials.access_token;
+  }
 
   spashttp.request(params, credentials, function (err, playlistResult) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spas-youtube",
   "description": "YouTube API helpers for SPAS",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "author": {
     "name": "Donovan Buck",
     "email": "donovan@donovan.bz",


### PR DESCRIPTION
## Features
- Function to retrieve channels
- Function to retrieve playlists
- Function to retrieve videos with details
- Function to search
- `playlistItems` and `playlistItemsWithTags` can retrieve `uploads` playlist ID if not set in `params`
## Performance Improvements
- `playlistItemsWithTags` now makes less requests thanks to `videos` function. `videos` endpoint can take a comma-separated list of IDs instead, so we can get details of 50 videos per request, reducing # requests from `N` to `N div 50`.
- Support passing `params.key` when OAuth is not needed.
## Bug Fixes
- Clean up for jshint ( @jlafitte )
- Uniform tab vs spaces ( @jlafitte )
- Return error in API response's body as actual error
- Ensure credentials are used. `spas-http` does not handle `access_token` in `credentials`, so we need
  to add it to the `params` manually so we don't have limit restriction.
- Fix a bug when `credentials` is not provided. When a bundle does not require authentication, credentials is null, which would cause spas to crash.
## Breaking Changes
-  `playlistItems` and `playlistItemsWithTags` both now return the full structure instead of just snippet. This is to ensure when `params.part` is set, correct data are returned to user.
- `playlistItemsWithTags` returns data with a little difference than `playlistItems`. They are the `snippet`, or `contentDetails` or any that are of `video` resource. `playlistItems` returns data of `playlistItem` resource. 
